### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -211,7 +211,7 @@ things such as ldfs, cdfs, and complete triangles.
 
 .. code:: python
 
-    RAA_CL.ultimates.astype(int)
+    RAA_CL.full_triangle['Ult'].astype(int)
 
 
 


### PR DESCRIPTION
Updated the documentation to show the ultimates being pulled from the full_triangle and not as a separate attribute.  It could also be written as full_triangle.Ult.astype(int)  but I like to have my columns more explicit.